### PR TITLE
sets maxWidth prop on shows page's layout component

### DIFF
--- a/pages/shows.js
+++ b/pages/shows.js
@@ -5,7 +5,10 @@ import { getAllShows } from '@l/graphcms'
 
 export default function Shows({ shows }) {
   return (
-    <Layout title="next-graphcms-shows / Shows">
+    <Layout
+      title="next-graphcms-shows / Shows"
+      maxWidth="900px"
+    >
       <Title>Shows</Title>
       <Grid>
         {shows.map(show => (


### PR DESCRIPTION
# Summary

Although there are many different ways to address this fix, it is important to utilize existing functionality in order to maintain consistency across the project, along with the benefit of having a cleaner codebase.

![Issue #9](https://user-images.githubusercontent.com/35074001/116491449-e01c9700-a867-11eb-831b-07d12f5cd0f2.png)

The simplest solution to resolve the width issue is to utilize the `maxWidth` prop that exists on the `Layout` component. 
Using the Home/index page as a reference for the layout structure for the Shows page, we can see that the `maxWidth` is set to `800px`, thus the same dimensions are applied to the Shows page's Layout wrapper.
