### PR TITLE
adjusts margins and padding on CardStyle and GridStyle

### DIFF
--- a/components/Grid/index.js
+++ b/components/Grid/index.js
@@ -46,7 +46,7 @@ const StyledGrid = styled.div`
     width: auto;
     flex-direction: row;
     align-items: flex-start;
-    justify-content: center;
+    justify-content: space-around;
   }
 `
 

--- a/components/Grid/index.js
+++ b/components/Grid/index.js
@@ -1,9 +1,8 @@
 import Link from 'next/link'
-import styled, { css } from 'styled-components'
-import { truncateText } from '@l/utils'
+import styled, {css} from 'styled-components'
+import {truncateText} from '@l/utils'
 
 const CardStyle = css`
-  margin: 1rem;
   flex-basis: 45%;
   padding: 1.5rem;
   text-align: left;
@@ -12,6 +11,8 @@ const CardStyle = css`
   border: 1px solid var(--gallery-grey);
   border-radius: 10px;
   transition: 150ms ease;
+  width: 100%;
+  margin: 0 0 1rem 0;
 
   :hover,
   :focus,
@@ -39,14 +40,17 @@ const StyledGrid = styled.div`
   flex-wrap: wrap;
   margin-top: 1rem;
   width: 100%;
+  padding: 1rem;
 
   @media (min-width: 600px) {
     width: auto;
     flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
   }
 `
 
-export function Card({ children, header, href, title }) {
+export function Card({children, header, href, title}) {
   return href ? (
     <Link href={href} passHref>
       <a css={CardStyle} title={title}>
@@ -62,7 +66,7 @@ export function Card({ children, header, href, title }) {
   )
 }
 
-export function Grid({ children }) {
+export function Grid({children}) {
   return (
     <StyledGrid>
       {children}

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -23,7 +23,8 @@ export default function Layout({
 
       <Main
         maxWidth={maxWidth}
-        alignItems={alignItems}>
+        alignItems={alignItems}
+      >
         {children}
       </Main>
 

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,16 +1,16 @@
 import Layout from '@c/Layout'
-import { Grid, Card } from '@c/Grid'
-import { Title } from '@c/Title'
-import { getAllShows } from '@l/graphcms'
+import {Grid, Card} from '@c/Grid'
+import {Title} from '@c/Title'
+import {getAllShows} from '@l/graphcms'
 
-export default function Shows({ shows }) {
+export default function Shows({shows}) {
   return (
-    <Layout title="next-graphcms-shows / Shows">
+    <Layout title="next-graphcms-shows / Shows" maxWidth="800px">
       <Title>Shows</Title>
       <Grid>
         {shows.map(show => (
           <Card href={`/show/${show.slug}`} header={show.title} key={show.id}>
-            <p>{show.artists.map(({ fullName }) => fullName).join(', ')}</p>
+            <p>{show.artists.map(({fullName}) => fullName).join(', ')}</p>
           </Card>
         ))}
       </Grid>
@@ -21,6 +21,6 @@ export default function Shows({ shows }) {
 export async function getServerSideProps() {
   const shows = (await getAllShows()) || []
   return {
-    props: { shows },
+    props: {shows},
   }
 }


### PR DESCRIPTION
# Summary

|Prev|After|
|----|-----|
|![Screen Shot 2021-04-28 at 9 59 22 PM](https://user-images.githubusercontent.com/35074001/116493834-87e89380-a86d-11eb-9d5a-ac6ea598d1e6.png)|![Screen Shot 2021-04-28 at 10 00 43 PM](https://user-images.githubusercontent.com/35074001/116493846-8fa83800-a86d-11eb-9eef-cda7241d4350.png)|

The main issue causing the inconsistent card widths can be attributed to the fact that there is no explicitly set width in the `CardStyle` component. To resolve this, the width is set to `100%` and the `margin: 1rem` is replaced with a simple bottom margin. To prevent this change from altering the non-mobile styles, the margin is set back to `1rem` for screens wider than 600px.

Also, from a UX perspective, to prevent the card layout from forcing a column direction at the ~670px breakpoint, I retroactively adjusted the margin from 1 to 0.5.


