### PR TITLE
sets inline ternaries for conditional render

### DIFF
--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -40,6 +40,7 @@ const Portrait = ({ images = [] }) => {
 }
 
 export default function Shows({ show }) {
+  console.log(show);
   return (
     <Layout title={`${show.title} / next-graphcms-shows`} maxWidth="900px" padding="0 2em">
       <Title>{show.title}</Title>
@@ -58,10 +59,10 @@ export default function Shows({ show }) {
           <Portrait images={artist.images} />
 
           <FlexyRow justify="flex-start">
-            <a href={artist.webUrl} target="_blank">Website</a>
-            <a href={artist.facebookUrl} target="_blank">Facebook</a>
-            <a href={artist.instagramUrl} target="_blank">Instagram</a>
-            <a href={artist.youTubeUrl} target="_blank">YouTube</a>
+            {artist.webUrl && <a href={artist.webUrl} target="_blank">Website</a>}
+            {artist.facebookUrl && <a href={artist.facebookUrl} target="_blank">Facebook</a>}
+            {artist.instagramUrl && <a href={artist.instagramUrl} target="_blank">Instagram</a>}
+            {artist.youTubeUrl && <a href={artist.youTubeUrl} target="_blank">YouTube</a>}
           </FlexyRow>
 
           <Markdown source={artist.bio} />


### PR DESCRIPTION
# Summary

|Prev|After|
|----|-----|
|<img width="424" alt="Screen Shot 2021-04-28 at 10 30 17 PM" src="https://user-images.githubusercontent.com/35074001/116495732-83be7500-a871-11eb-8a08-273ef656d21c.png">|<img width="424" alt="Screen Shot 2021-04-28 at 10 29 15 PM" src="https://user-images.githubusercontent.com/35074001/116495743-89b45600-a871-11eb-8de8-9ce3b0526bd9.png">|

This feature implementation was by far the most straightforward. By including inline ternary operators with each anchor element render, we are able to render only the links that exist.

Additionally, I personally believe restructuring the `show` prop would be very beneficial in a component like this. Not only does it look cleaner in my opinion, but it also saves some time by not having to type `artist` or `show` whenever you want to access the prop object.