### PR TITLE
Bugfix link url protocol

### DIFF
--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -40,7 +40,19 @@ const Portrait = ({ images = [] }) => {
 }
 
 export default function Shows({ show }) {
-  console.log(show);
+  
+  function checkProtocol(link)
+  {
+    if (link.indexOf("http://") == 0 || link.indexOf("https://") == 0) {
+      console.log("The link has http or https.");
+      return true;
+    }
+    else{
+      console.log("The link doesn't have http or https.");
+      return false;
+    }
+  }
+  
   return (
     <Layout title={`${show.title} / next-graphcms-shows`} maxWidth="900px" padding="0 2em">
       <Title>{show.title}</Title>
@@ -59,7 +71,7 @@ export default function Shows({ show }) {
           <Portrait images={artist.images} />
 
           <FlexyRow justify="flex-start">
-            {artist.webUrl && <a href={artist.webUrl} target="_blank">Website</a>}
+            {artist.webUrl && <a href={checkProtocol(artist.webUrl) ? artist.webUrl : `https://${artist.webUrl}`} target="_blank">Website</a>}
             {artist.facebookUrl && <a href={artist.facebookUrl} target="_blank">Facebook</a>}
             {artist.instagramUrl && <a href={artist.instagramUrl} target="_blank">Instagram</a>}
             {artist.youTubeUrl && <a href={artist.youTubeUrl} target="_blank">YouTube</a>}

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -40,6 +40,7 @@ const Portrait = ({ images = [] }) => {
 }
 
 export default function Shows({ show }) {
+  console.log(show);
   return (
     <Layout title={`${show.title} / next-graphcms-shows`} maxWidth="900px" padding="0 2em">
       <Title>{show.title}</Title>
@@ -58,10 +59,10 @@ export default function Shows({ show }) {
           <Portrait images={artist.images} />
 
           <FlexyRow justify="flex-start">
-            <a href={artist.webUrl} target="_blank">Website</a>
-            <a href={artist.facebookUrl} target="_blank">Facebook</a>
-            <a href={artist.instagramUrl} target="_blank">Instagram</a>
-            <a href={artist.youTubeUrl} target="_blank">YouTube</a>
+            {artist.webUrl && <a href={artist.webUrl} target="_blank">Website</a>}
+            {artist.facebookUrl && <a href={artist.facebookUrl} target="_blank">Facebook</a>}
+            {artist.instagramUrl && <a href={artist.instagramUrl} target="_blank">Instagram</a>}
+            {artist.youTubeUrl && <a href={artist.youTubeUrl} target="_blank">YouTube</a>}
           </FlexyRow>
 
           <Markdown source={artist.bio} />


### PR DESCRIPTION
# Summary

|Prev|After|
|----|-----|
|![dreamstage_issue-pt1](https://user-images.githubusercontent.com/35074001/116496699-a81b5100-a873-11eb-9d10-3b91220c7e7a.gif)|![Mama-Said-30th-Anniversary-next-graphcms-shows](https://user-images.githubusercontent.com/35074001/116496712-ae113200-a873-11eb-95d0-6727b49648f6.gif)|

Although this issue could be solved using regex, I decided to try to use a neat es6 string method called `indexOf` which essentially takes a string as an argument and returns the position of the provided string argument. In this case, I wrote a function that checks if the beginning of the url (which should have an index of 0) starts with either protocols `http://` or `https://`, and returns true if it satisfies the condition, and false if it does not.

Then, I replaced the original href value of `artist.webUrl` which may potentially be missing the proper protocol, with the previously mentioned function taking the original href value as the argument and adds the proper protocol to the url if it does not exist.