### PR TITLE
adds spotifyUrl to graphql query and adds additional link on show page

### DIFF
--- a/lib/graphcms.js
+++ b/lib/graphcms.js
@@ -60,6 +60,7 @@ export async function getShowBySlug(slug) {
           instagramUrl
           youTubeUrl
           webUrl
+          spotifyUrl
           images {
             url
           }

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -75,6 +75,7 @@ export default function Shows({ show }) {
             {artist.facebookUrl && <a href={artist.facebookUrl} target="_blank">Facebook</a>}
             {artist.instagramUrl && <a href={artist.instagramUrl} target="_blank">Instagram</a>}
             {artist.youTubeUrl && <a href={artist.youTubeUrl} target="_blank">YouTube</a>}
+            {artist.spotifyUrl && <a href={artist.spotifyUrl} target="_blank">Spotify</a>}
           </FlexyRow>
 
           <Markdown source={artist.bio} />


### PR DESCRIPTION
# Summary

|Prev|After|
|----|-----|
|<img width="424" alt="Screen Shot 2021-04-28 at 10 30 17 PM" src="https://user-images.githubusercontent.com/35074001/116498739-6e991480-a878-11eb-9055-b05152ebb58b.png">|<img width="426" alt="Screen Shot 2021-04-28 at 11 22 48 PM" src="https://user-images.githubusercontent.com/35074001/116498816-a738ee00-a878-11eb-8709-382e00bcddd2.png">|

First, by adding `spotifyUrl` to the query we are able to access the URL (if it exists) on the `artist` object.

Once `spotifyUrl` is queryable, I just copy and pasted the previous link and replaced the prop URLs with the correct ones.