### PR TITLE
adds artist route, refactors md and portrait components

### DIFF
--- a/components/Markdown/index.js
+++ b/components/Markdown/index.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import ReactMarkdown from 'react-markdown';
+
+const Markdown = styled(ReactMarkdown)`
+  img {
+    width: 100%;
+    border-radius: 20px;
+    border: 4px solid currentColor;
+  }
+`;
+
+export default Markdown;

--- a/components/Portrait/index.js
+++ b/components/Portrait/index.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const ArtistPhoto = styled.div`
+  background-image: url(${(p) => p.imageUrl});
+  background-repeat: no-repeat;
+  background-size: cover;
+  width: 200px;
+  height: 200px;
+  border-radius: 100px;
+  border: 4px solid currentColor;
+  margin: 2rem auto;
+`;
+
+const Portrait = ({ images = [] }) => {
+  if (images.length > 0) {
+    const img = images[0];
+    return <ArtistPhoto imageUrl={img.url} />;
+  }
+  return null;
+};
+
+export default Portrait;

--- a/lib/graphcms.js
+++ b/lib/graphcms.js
@@ -9,16 +9,16 @@ async function fetchAPI(query, variables = {}) {
       query,
       variables,
     }),
-  })
-  const json = await res.json()
+  });
+  const json = await res.json();
 
   if (json.errors) {
-    console.log(process.env.NEXT_EXAMPLE_CMS_GCMS_PROJECT_ID)
-    console.error(json.errors)
-    throw new Error('Failed to fetch API')
+    console.log(process.env.NEXT_EXAMPLE_CMS_GCMS_PROJECT_ID);
+    console.error(json.errors);
+    throw new Error('Failed to fetch API');
   }
 
-  return json.data
+  return json.data;
 }
 
 /**
@@ -38,8 +38,8 @@ export async function getAllShows() {
         }
       }
     }`
-  )
-  return data.shows
+  );
+  return data.shows;
 }
 
 /**
@@ -61,6 +61,7 @@ export async function getShowBySlug(slug) {
           youTubeUrl
           webUrl
           spotifyUrl
+          slug
           images {
             url
           }
@@ -71,8 +72,8 @@ export async function getShowBySlug(slug) {
       }
     }`,
     { slug }
-  )
-  return data.show
+  );
+  return data.show;
 }
 
 /**
@@ -94,6 +95,29 @@ export async function getSchemaByName(name) {
       }
     }`,
     { name }
-  )
-  return data['__type']
+  );
+  return data['__type'];
+}
+
+export async function getArtistBySlug(slug) {
+  const data = await fetchAPI(
+    `query ($slug: String!) {
+      artist(where: {slug: $slug}) {
+        id
+        bio
+        fullName
+        facebookUrl
+        instagramUrl
+        youTubeUrl
+        webUrl
+        spotifyUrl
+        slug
+        images {
+          url
+        }
+      }
+    }`,
+    { slug }
+  );
+  return data.artist;
 }

--- a/pages/artist/[slug].js
+++ b/pages/artist/[slug].js
@@ -1,0 +1,80 @@
+import Markdown from '../../components/Markdown';
+import styled from 'styled-components';
+import Layout from '@c/Layout';
+import FlexyRow from '@c/FlexyRow';
+import { getArtistBySlug } from '@l/graphcms';
+import Portrait from '../../components/Portrait';
+
+const ArtistName = styled.h2`
+  text-align: center;
+`;
+
+export default function Artist({ artist }) {
+  function checkProtocol(link) {
+    if (link.indexOf('http://') === 0 || link.indexOf('https://') === 0) {
+      console.log('The link has http or https.');
+      return true;
+    } else {
+      console.log("The link doesn't have http or https.");
+      return false;
+    }
+  }
+
+  return (
+    <Layout
+      title={`${artist.fullName} / next-graphcms-shows`}
+      maxWidth="900px"
+      padding="0 2em"
+    >
+      <div key={artist.id}>
+        <ArtistName>{artist.fullName}</ArtistName>
+        <Portrait images={artist.images} />
+        <FlexyRow justify="flex-start">
+          {artist.webUrl && (
+            <a
+              href={
+                checkProtocol(artist.webUrl)
+                  ? artist.webUrl
+                  : `https://${artist.webUrl}`
+              }
+              target="_blank"
+            >
+              Website
+            </a>
+          )}
+          {artist.facebookUrl && (
+            <a href={artist.facebookUrl} target="_blank">
+              Facebook
+            </a>
+          )}
+          {artist.instagramUrl && (
+            <a href={artist.instagramUrl} target="_blank">
+              Instagram
+            </a>
+          )}
+          {artist.youTubeUrl && (
+            <a href={artist.youTubeUrl} target="_blank">
+              YouTube
+            </a>
+          )}
+          {artist.spotifyUrl && (
+            <a href={artist.spotifyUrl} target="_blank">
+              Spotify
+            </a>
+          )}
+        </FlexyRow>
+
+        <Markdown source={artist.bio} />
+      </div>
+    </Layout>
+  );
+}
+
+export async function getServerSideProps({ params }) {
+  const { slug } = params;
+  const artist = await getArtistBySlug(slug);
+  console.log(artist);
+  return {
+    props: { artist },
+  };
+}

--- a/pages/artist/[slug].js
+++ b/pages/artist/[slug].js
@@ -2,10 +2,11 @@ import Markdown from '../../components/Markdown';
 import styled from 'styled-components';
 import Layout from '@c/Layout';
 import FlexyRow from '@c/FlexyRow';
+import { Title } from '@c/Title';
 import { getArtistBySlug } from '@l/graphcms';
 import Portrait from '../../components/Portrait';
 
-const ArtistName = styled.h2`
+const ArtistName = styled(Title)`
   text-align: center;
 `;
 

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -1,95 +1,47 @@
-import ReactMarkdown from 'react-markdown'
-import styled from 'styled-components'
-import Layout from '@c/Layout'
-import FlexyRow from '@c/FlexyRow'
-import { Title } from '@c/Title'
-import { getShowBySlug } from '@l/graphcms'
-import { formatUSD, formatDate } from '@l/utils'
-
-const Markdown = styled(ReactMarkdown)`
-  img {
-    width: 100%;
-    border-radius: 20px;
-    border: 4px solid currentColor;
-  }
-`
+import ReactMarkdown from 'react-markdown';
+import styled from 'styled-components';
+import Layout from '@c/Layout';
+import FlexyRow from '@c/FlexyRow';
+import { Title } from '@c/Title';
+import { getShowBySlug } from '@l/graphcms';
+import { formatUSD, formatDate } from '@l/utils';
+import Markdown from '../../components/Markdown';
+import Portrait from '../../components/Portrait';
 
 const ArtistName = styled.h2`
   text-align: center;
-`
+`;
 
-const ArtistPhoto = styled.div`
-  background-image: url(${(p) => p.imageUrl});
-  background-repeat: no-repeat;
-  background-size: cover;
-  width: 200px;
-  height: 200px;
-  border-radius: 100px;
-  border: 4px solid currentColor;
-  margin: 0 auto;
-`
 
-const Portrait = ({ images = [] }) => {
-  if (images.length > 0) {
-    const img = images[0]
-    return (
-      <ArtistPhoto imageUrl={img.url} />
-    )
-  }
-  return null
-}
 
 export default function Shows({ show }) {
-  
-  function checkProtocol(link)
-  {
-    if (link.indexOf("http://") == 0 || link.indexOf("https://") == 0) {
-      console.log("The link has http or https.");
-      return true;
-    }
-    else{
-      console.log("The link doesn't have http or https.");
-      return false;
-    }
-  }
-  
   return (
-    <Layout title={`${show.title} / next-graphcms-shows`} maxWidth="900px" padding="0 2em">
+    <Layout
+      title={`${show.title} / next-graphcms-shows`}
+      maxWidth="900px"
+      padding="0 2em"
+    >
       <Title>{show.title}</Title>
-
       <FlexyRow>
         <span>Price: {formatUSD(show.ticketPrice)}</span>
         <span>{formatDate(show.scheduledStartTime)}</span>
       </FlexyRow>
-
       <Markdown source={show.description} />
-
-      {show.artists.map(artist => (
-        <div key={artist.id}>
+      {show.artists.map((artist) => (
+        <a href={`/artist/${artist.slug}`} key={artist.id}>
           <ArtistName>{artist.fullName}</ArtistName>
-
           <Portrait images={artist.images} />
-
-          <FlexyRow justify="flex-start">
-            {artist.webUrl && <a href={checkProtocol(artist.webUrl) ? artist.webUrl : `https://${artist.webUrl}`} target="_blank">Website</a>}
-            {artist.facebookUrl && <a href={artist.facebookUrl} target="_blank">Facebook</a>}
-            {artist.instagramUrl && <a href={artist.instagramUrl} target="_blank">Instagram</a>}
-            {artist.youTubeUrl && <a href={artist.youTubeUrl} target="_blank">YouTube</a>}
-            {artist.spotifyUrl && <a href={artist.spotifyUrl} target="_blank">Spotify</a>}
-          </FlexyRow>
-
-          <Markdown source={artist.bio} />
-        </div>
+        </a>
       ))}
     </Layout>
-  )
+  );
 }
 
 export async function getServerSideProps({ params }) {
-  const { slug } = params
-  const show = (await getShowBySlug(slug))
+  const { slug } = params;
+  const show = await getShowBySlug(slug);
 
   return {
     props: { show },
-  }
+  };
 }


### PR DESCRIPTION
# Summary

|Prev|After|
|----|-----|
|![Screen Shot 2021-04-30 at 2 17 35 AM](https://user-images.githubusercontent.com/35074001/116656720-256dc100-a95b-11eb-8321-cd651613ac6e.png)|![Screen Shot 2021-04-30 at 2 18 01 AM](https://user-images.githubusercontent.com/35074001/116656657-0b33e300-a95b-11eb-9c3c-467d8d84b9e7.png) ![Screen Shot 2021-04-30 at 2 19 13 AM](https://user-images.githubusercontent.com/35074001/116656661-0e2ed380-a95b-11eb-8b00-adfaca5f01bb.png)||

As noted in the acceptance criteria, the artist query shares many properties with the show query. Also, by essentially duplicating the show component and making a few modifications, we are able to transfer the necessary content to the new page.