### PR TITLE
sets fallpack component for 404 page

### DIFF
--- a/components/Title/index.js
+++ b/components/Title/index.js
@@ -7,7 +7,7 @@ const H1 = styled.h1`
   text-align: ${(p) => p.textAlign};
 
   @media (min-width: 500px) {
-    font-size: 4rem;
+    font-size: 5rem;
   }
 `;
 

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -1,4 +1,4 @@
-import ReactMarkdown from 'react-markdown';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import Layout from '@c/Layout';
 import FlexyRow from '@c/FlexyRow';
@@ -12,9 +12,21 @@ const ArtistName = styled.h2`
   text-align: center;
 `;
 
-
-
 export default function Shows({ show }) {
+  const router = useRouter();
+
+  if (!router.isFallback && !show?.slug) {
+    // return <ErrorPage statusCode={404} />;
+    return (
+      <Layout>
+        <Title>404</Title>
+        <p style={{ fontSize: '1.6rem', marginTop: '2rem' }}>
+          Nothing to see here!
+        </p>
+      </Layout>
+    );
+  }
+
   return (
     <Layout
       title={`${show.title} / next-graphcms-shows`}


### PR DESCRIPTION
# Summary

Referencing Next's [documentation](https://nextjs.org/docs/basic-features/data-fetching#fallback-pages) on fallback pages, the implementation for setting a custom fallback component is relatively straightforward. Instead of using the built-in `ErrorPage` shown in [this example](https://github.com/vercel/next.js/blob/canary/examples/cms-graphcms/pages/posts/%5Bslug%5D.js), we render a simple component wrapped by `Layout` and add the remaining elements shown in the provided mockup.